### PR TITLE
fix:wrong result -> (zero or one) is shown as (one and only one)

### DIFF
--- a/netlify/functions/render-dml-to-mermaid.ts
+++ b/netlify/functions/render-dml-to-mermaid.ts
@@ -36,18 +36,18 @@ ${model.fields
         const thisSide = model.name;
         const otherSide = field.type;
 
-        let thisSideMultiplicity = "||";
+        let otherSideMultiplicity = "||";
         if (field.isList) {
-          thisSideMultiplicity = "}o";
+          otherSideMultiplicity = "}o";
         } else if (!field.isRequired) {
-          thisSideMultiplicity = "|o";
+          otherSideMultiplicity = "|o";
         }
         const otherModel = dml.models.find((model) => model.name == otherSide);
         const otherField = otherModel!.fields.find(
           ({ relationName }) => relationName === field.relationName
         );
 
-        let otherSideMultiplicity = "||";
+        let thisSideMultiplicity = "||";
         if (otherField!.isList) {
           thisSideMultiplicity = "o{";
         } else if (!otherField!.isRequired) {


### PR DESCRIPTION
a fix to [this issue](https://github.com/Skn0tt/prisma-erd/issues/13):

By investigating the current graph for the standard example we see the only change is that:
![image](https://github.com/Skn0tt/prisma-erd/assets/22705909/0d0831f4-f563-4d07-9562-0772c9a8288f)

has changed to:
![image](https://github.com/Skn0tt/prisma-erd/assets/22705909/b3f60a7d-68e6-4621-969a-85ee4622a5c7)

which is right since the schema is :
```
model Session {
  id                 Int       @id @default(autoincrement())
  createdAt          DateTime  @default(now())
  updatedAt          DateTime  @updatedAt
  expiresAt          DateTime?
  handle             String    @unique
  user               User?     @relation(fields: [userId], references: [id]) //   <-----------
  userId             Int?
  hashedSessionToken String?
  antiCSRFToken      String?
  publicData         String?
  privateData        String?
}
```

which is right since user is optional which mean it could be zero or one not one and only one